### PR TITLE
Hotfix position incident

### DIFF
--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -686,9 +686,9 @@ ${current.html_url}`
       tweet.length
     }/280 characters).`
   )
-  await twitter.post(`statuses/update`, {
-    status: tweet,
-  })
+//   await twitter.post(`statuses/update`, {
+//     status: tweet,
+//   })
 }
 
 /**


### PR DESCRIPTION
This is a hotfix that should prevent #59 from happening again (20 tweets being posted at once).

This simply disables the functionality. I should keep an eye out on the logs when actually fixing this.