### PR TITLE
Always run CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/workflows/backend.yml'
-      - 'backend/**'
 
 jobs:
   noop:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '.github/workflows/frontend.yml'
-      - 'frontend/*/**'
 
 jobs:
   analyze:


### PR DESCRIPTION
As the checks are now required for merging, we need to always run them (GitHub 😕).

Currently requiring the checks on `dev` as the app is also hosted using the `dev` channel :)

I think it is an awesome opportunity to play with the latest changes in a side project.