### PR TITLE
Add task for cleaning up tweets

### DIFF
--- a/backend/cloud_functions/package-lock.json
+++ b/backend/cloud_functions/package-lock.json
@@ -7,6 +7,7 @@
       "name": "functions",
       "dependencies": {
         "@google-cloud/secret-manager": "^4.1.3",
+        "@google-cloud/tasks": "^3.0.4",
         "@octokit/rest": "^19.0.5",
         "blurhash": "^2.0.3",
         "firebase-admin": "^11.2.0",
@@ -250,6 +251,17 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google-cloud/tasks": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-3.0.4.tgz",
+      "integrity": "sha512-XTWlyN0Fkod8WLWZ1/VuvEuQk1DJeXN40A69uQOyonM3Cae7b5KRCu0E8umWiuo8atItqJ196YqfX69hLc61lA==",
+      "dependencies": {
+        "google-gax": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -5667,6 +5679,14 @@
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
           "optional": true
         }
+      }
+    },
+    "@google-cloud/tasks": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/tasks/-/tasks-3.0.4.tgz",
+      "integrity": "sha512-XTWlyN0Fkod8WLWZ1/VuvEuQk1DJeXN40A69uQOyonM3Cae7b5KRCu0E8umWiuo8atItqJ196YqfX69hLc61lA==",
+      "requires": {
+        "google-gax": "^3.3.0"
       }
     },
     "@grpc/grpc-js": {

--- a/backend/cloud_functions/package.json
+++ b/backend/cloud_functions/package.json
@@ -16,6 +16,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@google-cloud/secret-manager": "^4.1.3",
+    "@google-cloud/tasks": "^3.0.4",
     "@octokit/rest": "^19.0.5",
     "blurhash": "^2.0.3",
     "firebase-admin": "^11.2.0",

--- a/backend/cloud_functions/src/application/backup/backup.ts
+++ b/backend/cloud_functions/src/application/backup/backup.ts
@@ -1,5 +1,5 @@
 import * as admin from 'firebase-admin';
-import { schedule } from 'firebase-functions/v1/pubsub';
+import * as v1 from 'firebase-functions/v1';
 
 const bucket = 'gs://github-tracker-backups';
 // The repos/<repo>/data collections are the only collection that
@@ -7,9 +7,11 @@ const bucket = 'gs://github-tracker-backups';
 // completely ephemeral as the data is updated every 15 minutes.
 const collections = ['data'];
 
-export const backupDataFunction =
+export const backupDataFunction = v1
+  .region('us-central1')
   // Backs up the whole Firestore database (repos collection) once per week.
-  schedule('0 0 * * 0').onRun(async (context) => {
+  .pubsub.schedule('0 0 * * 0')
+  .onRun(async (context) => {
     const projectId = process.env.GCP_PROJECT || process.env.GCLOUD_PROJECT;
     const client = new admin.firestore.v1.FirestoreAdminClient();
     const databaseName = client.databasePath(projectId!, '(default)');

--- a/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
+++ b/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
@@ -179,8 +179,9 @@ async function catchApiResponseError(e: ApiResponseError): Promise<void> {
   });
   console.info(
     loggingTag,
-    `Created task ${
-      response.name
-    } to retry cleaning up tweets at${retryDate.toISOString()}.`
+    'Created task',
+    response.name,
+    'to retry cleaning up tweets at',
+    retryDate.toISOString()
   );
 }

--- a/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
+++ b/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
@@ -135,6 +135,8 @@ async function catchApiResponseError(e: ApiResponseError): Promise<void> {
       `Retrying request at ${retryDate.toISOString()}.`
   );
 
+  // Schedule a Cloud Task at the reset time of the Twitter API rate limit
+  // to invoke the cleanUpTweetsHttpFunction and continue cleaning up.
   const url =
     'https://us-central1-github-tracker-b5c54.cloudfunctions.net/cleanuptweetshttps';
 

--- a/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
+++ b/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
@@ -167,7 +167,7 @@ async function catchApiResponseError(e: ApiResponseError): Promise<void> {
         oidcToken: {
           serviceAccountEmail:
             'clean-up-tweets-invoker@github-tracker-b5c54.iam.gserviceaccount.com',
-          audience: new URL(url).origin,
+          audience: url,
         },
         headers: {
           'Content-Type': 'application/json',

--- a/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
+++ b/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
@@ -1,6 +1,7 @@
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
-import { schedule } from 'firebase-functions/v1/pubsub';
-import { ApiResponseError, TwitterApi } from 'twitter-api-v2';
+import { v2beta3 } from '@google-cloud/tasks';
+import * as v1 from 'firebase-functions/v1';
+import { ApiResponseError, TweetV2, TwitterApi } from 'twitter-api-v2';
 import { SecretsAccessor } from '../../infrastructure/secrets';
 
 const secretManager = new SecretManagerServiceClient();
@@ -10,60 +11,162 @@ const secretManager = new SecretManagerServiceClient();
 // Tweets below this threshold are deemed irrelevant.
 let twitter: TwitterApi;
 
-// Any tweet with matching or less likes than this threshold will be deleted.
-const likesThreshold = 3;
-
 /**
  * Deletes all tweets matching or below the specified likes threshold that
  * is older than 8 days.
  *
  * The function is currently triggered on the first day of every month.
  */
-export const cleanUpTweetsFunction = schedule('0 0 1 * *').onRun(
-  async (context) => {
-    // Load the Twitter client asynchronously on cold start.
-    // The reason we have to do this is in order to ensure that
-    // the client is loaded before execution as it depends on secrets
-    // that can only be loaded asynchronously from secret manager.
-    if (twitter === undefined) {
-      const secretsAccessor = new SecretsAccessor(secretManager);
-      twitter = new TwitterApi({
-        appKey: await secretsAccessor.access('TWITTER_APP_CONSUMER_KEY'),
-        appSecret: await secretsAccessor.access(
-          'TWITTER_APP_CONSUMER_KEY_SECRET'
-        ),
-        accessToken: await secretsAccessor.access('TWITTER_APP_ACCESS_TOKEN'),
-        accessSecret: await secretsAccessor.access(
-          'TWITTER_APP_ACCESS_TOKEN_SECRET'
-        ),
-      });
-    }
+export const cleanUpTweetsScheduledFunction = v1.pubsub
+  .schedule('0 0 1 * *')
+  .onRun(async (context) => cleanUpTweets());
 
-    const date = new Date();
-    date.setDate(date.getDate() - 8);
-
-    const paginator = await twitter.v2.userTimeline('1363301907033444353', {
-      max_results: 100,
-      end_time: date.toISOString(),
-      'tweet.fields': ['public_metrics'],
-    });
-    let count = 0,
-      deleted = 0;
+/**
+ * HTTPs trigger for cleaning up tweets that allows execution via Cloud Tasks.
+ */
+export const cleanUpTweetsHttpFunction = v1.https.onRequest(
+  async (request, response) => {
     try {
-      for await (const [tweet, _] of paginator.fetchAndIterate()) {
-        count++;
-        if (tweet.public_metrics!.like_count > likesThreshold) continue;
-        console.info(
-          `Deleting tweet with id="${tweet.id}" as it does not have more than ${likesThreshold} likes.`
-        );
-        await twitter.v2.deleteTweet(tweet.id);
-        deleted++;
-      }
+      cleanUpTweets();
     } catch (e) {
-      if (e instanceof ApiResponseError) {
-        console.error(e.message);
-      }
+      response.status(500);
+      response.send({
+        error: e,
+      });
+      return;
     }
-    console.info(`Deleted ${deleted}/${count} tweets.`);
+
+    response.status(200);
   }
 );
+
+async function cleanUpTweets(): Promise<void> {
+  // Load the Twitter client asynchronously on cold start.
+  // The reason we have to do this is in order to ensure that
+  // the client is loaded before execution as it depends on secrets
+  // that can only be loaded asynchronously from secret manager.
+  if (twitter === undefined) {
+    const secretsAccessor = new SecretsAccessor(secretManager);
+    twitter = new TwitterApi({
+      appKey: await secretsAccessor.access('TWITTER_APP_CONSUMER_KEY'),
+      appSecret: await secretsAccessor.access(
+        'TWITTER_APP_CONSUMER_KEY_SECRET'
+      ),
+      accessToken: await secretsAccessor.access('TWITTER_APP_ACCESS_TOKEN'),
+      accessSecret: await secretsAccessor.access(
+        'TWITTER_APP_ACCESS_TOKEN_SECRET'
+      ),
+    });
+  }
+
+  // Any tweet with matching or less likes than this threshold will be deleted.
+  const likesThreshold = 14;
+  // Any tweet after the date threshold will be deleted.
+  const dateThreshold = new Date();
+  dateThreshold.setDate(dateThreshold.getDate() - 8);
+
+  const paginator = await twitter.v2.userTimeline('1363301907033444353', {
+    max_results: 100,
+    end_time: dateThreshold.toISOString(),
+    'tweet.fields': ['public_metrics'],
+  });
+  let count = 0;
+  const tweetsToDelete: Array<TweetV2> = [];
+  try {
+    for await (const [tweet, _] of paginator.fetchAndIterate()) {
+      count++;
+      if (tweet.public_metrics!.like_count > likesThreshold) continue;
+      if (new Date(tweet.created_at!) > dateThreshold) continue;
+      tweetsToDelete.push(tweet);
+    }
+  } catch (e) {
+    if (e instanceof ApiResponseError) {
+      await catchApiResponseError(e);
+      return;
+    }
+  } finally {
+    console.info(
+      `Fetched ${count} tweets. ` +
+        `${tweetsToDelete.length} of those should be cleaned up.`
+    );
+  }
+
+  tweetsToDelete.sort(function (a, b) {
+    // Sort the latest tweets first.
+    return new Date(a.created_at!) < new Date(b.created_at!) ? -1 : 1;
+  });
+  let deleted = 0;
+  try {
+    for (const tweet of tweetsToDelete) {
+      console.info(
+        `Deleting tweet with id="${tweet.id}" as it does not have more than ${likesThreshold} likes.`
+      );
+      await twitter.v2.deleteTweet(tweet.id);
+      deleted++;
+    }
+  } catch (e) {
+    if (e instanceof ApiResponseError) {
+      await catchApiResponseError(e);
+      return;
+    }
+  } finally {
+    console.info(`Deleted ${deleted}/${tweetsToDelete.length} tweets.`);
+  }
+}
+
+/**
+ * Catches an @type {ApiResponseError} from the Twitter v2 API.
+ *
+ * In case the error occurred due to a rate limit error, schedules
+ * the cleanUpTweetsFunction to run again once the rate limit has reset.
+ */
+async function catchApiResponseError(e: ApiResponseError): Promise<void> {
+  if (!e.rateLimitError) {
+    console.error(`Cleaning up tweets was cancelled due to ${e.message}`);
+    return;
+  }
+  const rateLimit = e.rateLimit!;
+  if (rateLimit.remaining !== 0 || rateLimit.limit === 0) return;
+
+  const retryDate = new Date(rateLimit.reset * 1000);
+  console.warn(
+    'Twitter API rate limit was reached ' +
+      `(0/${rateLimit.limit} requests remaining). ` +
+      `Retrying request at ${retryDate.toISOString()}.`
+  );
+
+  const url =
+    'https://us-central1-github-tracker-b5c54.cloudfunctions.net/cleanuptweetshttps';
+
+  const client = new v2beta3.CloudTasksClient();
+  const parent = client.queuePath(
+    'github-tracker-b5c54',
+    'us-central1',
+    'clean-up-tweets-queue'
+  );
+  const [response] = await client.createTask({
+    parent,
+    task: {
+      httpRequest: {
+        httpMethod: 'POST',
+        url,
+        oidcToken: {
+          serviceAccountEmail:
+            'clean-up-tweets-invoker@github-tracker-b5c54.iam.gserviceaccount.com',
+          audience: new URL(url).origin,
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      scheduleTime: {
+        seconds: retryDate.getTime() / 1000,
+      },
+    },
+  });
+  console.info(
+    `Created task ${
+      response.name
+    } to retry cleaning up tweets at${retryDate.toISOString()}.`
+  );
+}

--- a/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
+++ b/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
@@ -19,8 +19,9 @@ const loggingTag = '[clean-up-tweets]';
  *
  * The function is currently triggered on the first day of every month.
  */
-export const cleanUpTweetsScheduledFunction = v1.pubsub
-  .schedule('0 0 1 * *')
+export const cleanUpTweetsScheduledFunction = v1
+  .region('us-central1')
+  .pubsub.schedule('0 0 1 * *')
   .onRun(async (context) => cleanUpTweets());
 
 /**

--- a/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
+++ b/backend/cloud_functions/src/application/clean_up_tweets/clean_up_tweets.ts
@@ -142,7 +142,7 @@ async function catchApiResponseError(e: ApiResponseError): Promise<void> {
   const retryDate = new Date(rateLimit.reset * 1000);
   console.warn(
     loggingTag,
-    'Twitter API rate limit was reached ',
+    'Twitter API rate limit has been reached ',
     `(0/${rateLimit.limit} requests remaining). `,
     `Retrying request at ${retryDate.toISOString()}.`
   );

--- a/backend/cloud_functions/src/application/freeze/freeze.ts
+++ b/backend/cloud_functions/src/application/freeze/freeze.ts
@@ -1,18 +1,22 @@
 import { getFirestore, Timestamp, WriteBatch } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
-import { schedule } from 'firebase-functions/v1/pubsub';
+import * as v1 from 'firebase-functions/v1';
 
 const bucket = 'gs://github-tracker-freezer';
 
-export const freezeDataFunction =
-  // Extracts all stored data older than 31 days old from Firestore to
-  // a JSON file that is stored a Cloud Storage bucket.
-  // We choose 31 days over 28 days since we want to track the fastest growing
-  // repo of the month at the end of each month.
-  // We do this in order to reduce the cost of backing up the Firestore
-  // data every week.
-  // This runs so frequently because we want to keep the JSON files small.
-  schedule('0 */3 * * *').onRun(async (context) => {
+/**
+ * Extracts all stored data older than 31 days old from Firestore to
+ * a JSON file that is stored a Cloud Storage bucket.
+ * We choose 31 days over 28 days since we want to track the fastest growing
+ * repo of the month at the end of each month.
+ * We do this in order to reduce the cost of backing up the Firestore
+ * data every week.
+ * This runs so frequently because we want to keep the JSON files small.
+ */
+export const freezeDataFunction = v1
+  .region('us-central1')
+  .pubsub.schedule('0 */3 * * *')
+  .onRun(async (context) => {
     const firestore = getFirestore();
     const storage = getStorage();
     const snapshot = await firestore

--- a/backend/cloud_functions/src/application/track/data.ts
+++ b/backend/cloud_functions/src/application/track/data.ts
@@ -2,7 +2,7 @@ import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
 import { Octokit } from '@octokit/rest';
 import {
   Endpoints,
-  GetResponseDataTypeFromEndpointMethod
+  GetResponseDataTypeFromEndpointMethod,
 } from '@octokit/types';
 import {
   CollectionReference,
@@ -13,9 +13,9 @@ import {
   getFirestore,
   QueryDocumentSnapshot,
   Timestamp,
-  WriteBatch
+  WriteBatch,
 } from 'firebase-admin/firestore';
-import { schedule } from 'firebase-functions/v1/pubsub';
+import * as v1 from 'firebase-functions/v1';
 import { merge } from 'lodash';
 import numbro from 'numbro';
 import { TwitterApi } from 'twitter-api-v2';
@@ -124,8 +124,10 @@ function typedCollection<T>(path: string): CollectionReference<T> {
  * 2. Update the stats for the top 100 repos.
  * 3. Make the Twitter bot take actions based on that if certain events occur.
  */
-export const updateDataFunction = schedule('*/15 * * * *').onRun(
-  async (context) => {
+export const updateDataFunction = v1
+  .region('us-central1')
+  .pubsub.schedule('*/15 * * * *')
+  .onRun(async (context) => {
     initializeFirestore();
     await initializeTwitter();
     const tweetManager = new TweetManager(twitter);
@@ -346,8 +348,7 @@ export const updateDataFunction = schedule('*/15 * * * *').onRun(
 
     // Finally, tweet whatever tweet has the highest priority.
     await tweetManager.tweet();
-  }
-);
+  });
 
 /**
  * Makes the Twitter bot post the fastest growing repo of the month.
@@ -356,8 +357,10 @@ export const updateDataFunction = schedule('*/15 * * * *').onRun(
  * The function will only take action if the current day is the last day
  * of the particular month.
  */
-export const postMonthlyFunction = schedule('15 15 28-31 * *').onRun(
-  async (context) => {
+export const postMonthlyFunction = v1
+  .region('us-central1')
+  .pubsub.schedule('15 15 28-31 * *')
+  .onRun(async (context) => {
     // https://bobbyhadz.com/blog/javascript-check-if-date-is-last-day-of-month#check-if-a-date-is-the-last-day-of-the-month-in-javascript
     function isLastDayOfMonth() {
       const date = new Date();
@@ -463,8 +466,7 @@ export const postMonthlyFunction = schedule('15 15 28-31 * *').onRun(
 
     // Finally, tweet whatever tweet has the highest priority.
     await tweetManager.tweet();
-  }
-);
+  });
 
 /**
  * Fetches the top 100 software repos from the GitHub API.

--- a/backend/cloud_functions/src/application/track/data.ts
+++ b/backend/cloud_functions/src/application/track/data.ts
@@ -2,7 +2,7 @@ import { SecretManagerServiceClient } from '@google-cloud/secret-manager';
 import { Octokit } from '@octokit/rest';
 import {
   Endpoints,
-  GetResponseDataTypeFromEndpointMethod,
+  GetResponseDataTypeFromEndpointMethod
 } from '@octokit/types';
 import {
   CollectionReference,
@@ -13,7 +13,7 @@ import {
   getFirestore,
   QueryDocumentSnapshot,
   Timestamp,
-  WriteBatch,
+  WriteBatch
 } from 'firebase-admin/firestore';
 import { schedule } from 'firebase-functions/v1/pubsub';
 import { merge } from 'lodash';
@@ -365,7 +365,13 @@ export const postMonthlyFunction = schedule('15 15 28-31 * *').onRun(
       return new Date(date.getTime() + oneDayInMs).getDate() === 1;
     }
     // Early exit if the function was not triggered on the last day of the month.
-    if (!isLastDayOfMonth()) return;
+    if (!isLastDayOfMonth()) {
+      console.info(
+        `Not posting about the fastest growing repo of the month as today ${new Date().toISOString()} ` +
+          'is not the last of the month.'
+      );
+      return;
+    }
 
     initializeFirestore();
     await initializeTwitter();

--- a/backend/cloud_functions/src/index.ts
+++ b/backend/cloud_functions/src/index.ts
@@ -1,6 +1,9 @@
 import { initializeApp } from 'firebase-admin/app';
 import { backupDataFunction } from './application/backup/backup';
-import { cleanUpTweetsFunction } from './application/clean_up_tweets/clean_up_tweets';
+import {
+  cleanUpTweetsHttpFunction as cleanUpTweetsHttpsFunction,
+  cleanUpTweetsScheduledFunction,
+} from './application/clean_up_tweets/clean_up_tweets';
 import { freezeDataFunction } from './application/freeze/freeze';
 import {
   postMonthlyFunction,
@@ -13,4 +16,5 @@ exports.freezedata = freezeDataFunction;
 exports.updatedata = updateDataFunction;
 exports.backupdata = backupDataFunction;
 exports.postmonthly = postMonthlyFunction;
-exports.cleanuptweets = cleanUpTweetsFunction;
+exports.cleanuptweetsscheduled = cleanUpTweetsScheduledFunction;
+exports.cleanuptweetshttps = cleanUpTweetsHttpsFunction;


### PR DESCRIPTION
Add a Google Cloud Task in order to account for the Twitter API rate limit of 50 requests per 15 minutes (for deleting tweets).

A total of about 2,000 tweets have to be deleted.